### PR TITLE
Dockerfile: run all apt commands at once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,16 @@ FROM blitznote/debase:18.04
 RUN \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && perl -pi -e 's/archive.ubuntu.com/us.archive.ubuntu.com/' /etc/apt/sources.list \
-    && apt-get update -y
-
-RUN \
-    apt-get install -y \
-    libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1
-
-RUN \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
 ARG VER
 
 ADD out/headless-shell-$VER.tar.bz2 /
+
+ENV PATH="/headless-shell:${PATH}"
 
 EXPOSE 9222
 


### PR DESCRIPTION
Since the image is never squashed, running commands like apt-get clean
in a separate RUN command doesn't actually remove the files from the
final image.

Joining the RUN lines reduces the image size by 23MB.

While at it, set up PATH in the image so that headless-shell is runnable
from within a container. This is useful if the image is used with a
shell or another program, such as when running CI jobs or tests.