### PR TITLE
Add example command how to run as unprivileged user

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ $ docker run -d -p 9222:9222 --rm --name headless-shell chromedp/headless-shell
 
 # if headless-shell is crashing with a BUS_ADRERR error, pass a larger shm-size:
 $ docker run -d -p 9222:9222 --rm --name headless-shell --shm-size 2G chromedp/headless-shell
+
+# run as unprivileged user
+# get seccomp profile from https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json
+$ docker run -d -p 9222:9222 --user nobody --security-opt seccomp=chrome.json --entrypoint '/headless-shell/headless-shell' chromedp/headless-shell --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --disable-gpu --headless
 ```
 
 ## Building and Packaging

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tree is up-to-date.
 ### Building
 
 After you are able to successfully build `headless-shell` directly from the
-Chromium source tree, you can simply run [`docker-build.sh`](docker-build.sh):
+Chromium source tree, you can simply run [`build-docker.sh`](build-docker.sh):
 
 ```sh
 # build headless-shell


### PR DESCRIPTION
I was not comfortable having `headless-shell` run as root so here is how it can be run as an unprivileged user.