### PR TITLE
docs: Update README with missing snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ When using `chromedp/headless-shell` as a base image to build an image that runs
 FROM chromedp/headless-shell:latest
 ...
 # Install dumb-init or tini
+RUN apt update -y
 RUN apt install dumb-init
 # or RUN apt install tini
 ...
 ENTRYPOINT ["dumb-init", "--"]
 # or ENTRYPOINT ["tini", "--"]
+...
+ENV PATH=$PATH:/headless-shell
 CMD ["/path/to/your/program"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ FROM chromedp/headless-shell:latest
 ...
 # Install dumb-init or tini
 RUN apt update -y
-RUN apt install dumb-init
-# or RUN apt install tini
+RUN apt install -y dumb-init
+# or RUN apt -y install tini
 ...
 ENTRYPOINT ["dumb-init", "--"]
 # or ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
I am using this headless-shell as a base for my docker image hobby project. The `apt update -y` is a quite obvious one for Debian and Ubuntu users, but I added just in case someone never used those. The `ENV PATH` is required, otherwise `chromedp` returns an error stating it can't find `google-chrome`.

I thought about adding the `ENV PATH=$PATH:/headless-shell` to the `Dockerfile`, but I don't know if there was a reason to let it out of it. Hence, I just added it in the docs.