### PR TITLE
Fixed docker copy command for libraries in swiftshader directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 FROM debian:stable-slim
 
 RUN \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && apt-get update -y \
+    apt-get update -y \
     && apt-get install -y libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG VERSION
 
 COPY \
     out/$VERSION/headless-shell/headless-shell \
     out/$VERSION/headless-shell/.stamp \
-    out/$VERSION/headless-shell/swiftshader \
     /headless-shell/
+
+COPY \
+    out/$VERSION/headless-shell/swiftshader \
+    /headless-shell/swiftshader
 
 EXPOSE 9222
 


### PR DESCRIPTION
Errors as reported by chromium process:

```
[0501/104750.232090:WARNING:resource_bundle.cc(427)] locale_file_path.empty() for locale
[0501/104750.232907:ERROR:egl_util.cc(60)] Failed to load GLES library: /headless-shell/swiftshader/libGLESv2.so: /headless-shell/swiftshader/libGLESv2.so: cannot open shared object file: No such file or directory
[0501/104750.235560:ERROR:viz_main_impl.cc(159)] Exiting GPU process due to errors during initialization
```

_swiftshader libs_ are expected to be in `/headless-shell/swiftshader` directory.

```sh
docker run --rm --entrypoint=sh chromedp/headless-shell -c 'ls -lh /headless-shell/*'
-rwxrwxr-x 1 root root 139M Apr 27 23:08 /headless-shell/headless-shell
-rw-rw-r-- 1 root root 295K Apr 27 23:08 /headless-shell/libEGL.so
-rw-rw-r-- 1 root root 3.8M Apr 27 23:08 /headless-shell/libGLESv2.so
```

You need two docker COPY commands to copy `swiftshader` as a directory.