### PR TITLE
update debian to bullseye-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 ARG VERSION
 RUN \
     apt-get update -y \


### PR DESCRIPTION
Using the buster-slim image has resulted in 3 CVE's being flagged during container scanning due to outdated glibc libraries:
- CVE-2021-35942
- CVE-2021-33574
- CVE-2021-12403