### PR TITLE
Fixed location for swiftshader libraries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ RUN \
 COPY \
     out/$VERSION/headless-shell/headless-shell \
     out/$VERSION/headless-shell/.stamp \
-    /headless-shell/
-COPY \
     out/$VERSION/headless-shell/swiftshader \
-    /headless-shell/swiftshader
+    /headless-shell/
+
 EXPOSE 9222
 ENV PATH /headless-shell:$PATH
 ENTRYPOINT [ "/headless-shell/headless-shell", "--no-sandbox", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222" ]


### PR DESCRIPTION
It used to work with chrome 93, but with the latest version the following error occurs:

```
ERROR:egl_util.cc(74)] Failed to load GLES library: /headless-shell/libGLESv2.so:
/headless-shell/libGLESv2.so: cannot open shared object file: No such file or directory
```

with `--in-process-gpu` flag it cause crash.

swiftshader libraries are (again) expected to be in the same directory with executable.