### PR TITLE
configure the build to persist local state using prefs storage

### DIFF
--- a/build-headless-shell.sh
+++ b/build-headless-shell.sh
@@ -185,6 +185,7 @@ if [ "$SYNC" -eq "1" ]; then
   enable_nacl=false
   blink_symbol_level=0
   headless_use_embedded_resources=true
+  headless_use_prefs=true
   " > $PROJECT/args.gn
 
   # generate build files


### PR DESCRIPTION
The cookies are not persisted due to the breaking change introduced by chromium/chromium@7c64b00ce8ba4f984b8a48cf2a62025a9bf2fa48.

The headless-shell should works in the same way as Chrome to reduce surprises. So let's bring back the behavior before the commit mentioned above.

Fixes chromedp/chromedp#1078