### PR TITLE
change legacy SwiftShader GL to SwANGLE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,12 @@ RUN \
 COPY \
     out/$VERSION/headless-shell/headless-shell \
     out/$VERSION/headless-shell/.stamp \
-    out/$VERSION/headless-shell/*.so \
+    out/$VERSION/headless-shell/libEGL.so \
+    out/$VERSION/headless-shell/libGLESv2.so \
+    out/$VERSION/headless-shell/libvk_swiftshader.so \
+    out/$VERSION/headless-shell/libvulkan.so.1 \
+    out/$VERSION/headless-shell/vk_swiftshader_icd.json \
     /headless-shell/
 EXPOSE 9222
 ENV PATH /headless-shell:$PATH
-ENTRYPOINT [ "/headless-shell/headless-shell", "--no-sandbox", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222" ]
+ENTRYPOINT [ "/headless-shell/headless-shell", "--no-sandbox", "--use-gl=angle", "--use-angle=swiftshader", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222" ]

--- a/build-headless-shell.sh
+++ b/build-headless-shell.sh
@@ -197,7 +197,7 @@ for i in $(seq 1 $ATTEMPTS); do
   RET=1
   echo "STARTING BUILD ATTEMPT $i FOR $VERSION ($(date))"
   #$SRC/icecc-chromium/icecc-ninja -j $JOBS -C $PROJECT headless_shell chrome_sandbox && RET=$?
-  $SRC/depot_tools/ninja -j $JOBS -C $PROJECT headless_shell chrome_sandbox && RET=$?
+  $SRC/depot_tools/ninja -j $JOBS -C $PROJECT headless_shell && RET=$?
   if [ $RET -eq 0 ]; then
     echo "COMPLETED BUILD ATTEMPT $i FOR $VERSION ($(date))"
     break
@@ -214,18 +214,17 @@ echo $VERSION > $PROJECT/.stamp
 
 # copy files
 mkdir -p $TMPDIR/headless-shell
-cp -a $PROJECT/{headless_shell,chrome_sandbox,.stamp} $TMPDIR/headless-shell
-cp -a $PROJECT/swiftshader/*.so $TMPDIR/headless-shell
+cp -a $PROJECT/{headless_shell,.stamp} $TMPDIR/headless-shell
+cp -a $PROJECT/{libEGL.so,libGLESv2.so,libvk_swiftshader.so,libvulkan.so.1,vk_swiftshader_icd.json} $TMPDIR/headless-shell
 
 popd &> /dev/null
 
 pushd $TMPDIR/headless-shell &> /dev/null
 
 # rename and strip
-mv chrome_sandbox chrome-sandbox
 mv headless_shell headless-shell
-strip headless-shell chrome-sandbox *.so
-chmod -x *.so
+strip headless-shell *.so *.so.1
+chmod -x *.so *.so.1
 
 # verify headless-shell runs and reports correct version
 ./headless-shell --remote-debugging-port=5000 &> /dev/null & PID=$!


### PR DESCRIPTION
Legacy SwiftShader GL is deprecated, and the shared libraries on which `headless_shell` depends have changed (I called it `headless_shell` instead of `headless-shell` intentionally because I want to refer to the build artifact of the chromium source tree).

The dependencies of `headless_shell` are found with this command (run on the builder, assuming the directory is `out/Default`):

```shell
strace -o strace.log -f -e trace=open,openat \
    ./headless_shell --no-sandbox --use-gl=angle --use-angle=swiftshader \
    https://get.webgl.org/
```

Then grep for `out/Default`:

```shell
grep -F "out/Default" strace.log
```

Here is the list of found files:

- libEGL.so
- libGLESv2.so
- libvk_swiftshader.so
- libvulkan.so.1
- vk_swiftshader_icd.json

Notes:

1. there is a directory named `swiftshader` containing `libEGL.so` and `libGLESv2.so`, but they are not in use.
2. this is based on `102.0.5005.115`, and it seems that the code for GPU is a fast moving part. We should check frequently.
3. `chrome-sandbox` is not included in the final image (`chromedp/headless-shell`), so I removed it. But I'm worried that the builder uses a local modified `build-headless-shell.sh` that is not checked into the repository.

References:

- https://github.com/chromium/chromium/blob/main/docs/gpu/swiftshader.md
- https://bugs.chromium.org/p/chromium/issues/detail?id=1060139
- https://bugs.chromium.org/p/chromium/issues/detail?id=765284

Fixes chromedp/chromedp#1012
Fixes chromedp/chromedp#1073
Fixes chromedp/chromedp#1074