### PR TITLE
set the locale so that headless-shell can load the correct resource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ COPY \
     out/$VERSION/headless-shell/*.so \
     /headless-shell/
 EXPOSE 9222
+ENV LANG en-US.UTF-8
 ENV PATH /headless-shell:$PATH
 ENTRYPOINT [ "/headless-shell/headless-shell", "--no-sandbox", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222" ]


### PR DESCRIPTION
According to https://bugs.chromium.org/p/chromium/issues/detail?id=610673, `headless_lib.pak` should have been bundled into the headless library, so it should not need to copy it to the docker image and add a soft link to it as `en-US.pak`.

It turns out that we just need to set the locale to `en-US` to make it work.

Fixes chromedp/chromedp#922