### PR TITLE
turn on all optimizations by enabling official build mode

### DIFF
--- a/build-headless-shell.sh
+++ b/build-headless-shell.sh
@@ -181,9 +181,10 @@ if [ "$SYNC" -eq "1" ]; then
 #  import(\"$SRC/icecc-chromium/icecc.gni\") # icecc parameters (removed)
   echo "import(\"//build/args/headless.gn\")
   is_debug=false
+  is_official_build=true
   symbol_level=0
-  enable_nacl=false
   blink_symbol_level=0
+  enable_nacl=false
   headless_use_embedded_resources=true
   headless_use_prefs=true
   " > $PROJECT/args.gn


### PR DESCRIPTION
One of the optimizations is that it will reduce the file size of `headless_shell` remarkably. Here are the numbers for the stripped `headless_shell` at version `102.0.5005.115`:
- before: 194833880 (185M)
- after:  139810912 (133M, **-28%**)

The size issue has been mentioned in this comment before: https://github.com/chromedp/docker-headless-shell/pull/18#issuecomment-1152885570

Hopefully that it will address the issue https://github.com/chromedp/chromedp/issues/1075 too.