### PR TITLE
simplify the shell that filters out canary channels

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ set -e
 
 OMAHA="$(curl -s https://omahaproxy.appspot.com/all.json)"
 if [ -z "$CHANNELS" ]; then
-  CHANNELS=$(jq -r '.[] | select(.os == "win64") | .versions[] | .channel' <<< "$OMAHA"|grep -v 'canary'|tr '\r\n' ' '|sed -e 's/ $//')
+  CHANNELS=$(jq -r '.[] | select(.os == "win64") | .versions[] | .channel | select(. | contains("canary") | not)' <<< "$OMAHA")
 fi
 
 export PATH=$PATH:$HOME/src/misc/chrome/depot_tools


### PR DESCRIPTION
Use [contains(element)](https://stedolan.github.io/jq/manual/#contains(element)) filter and the [not](https://stedolan.github.io/jq/manual/#and/or/not) operator in `jq` to filter out `canary` channels.