### PR TITLE
feat: add support for multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ARG VERSION
+ARG TARGETARCH
 RUN \
     apt-get update -y \
     && apt-get install -y libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY \
-    out/$VERSION/headless-shell/headless-shell \
-    out/$VERSION/headless-shell/.stamp \
-    out/$VERSION/headless-shell/libEGL.so \
-    out/$VERSION/headless-shell/libGLESv2.so \
-    out/$VERSION/headless-shell/libvk_swiftshader.so \
-    out/$VERSION/headless-shell/libvulkan.so.1 \
-    out/$VERSION/headless-shell/vk_swiftshader_icd.json \
+    out/$VERSION/$TARGETARCH/headless-shell/headless-shell \
+    out/$VERSION/$TARGETARCH/headless-shell/.stamp \
+    out/$VERSION/$TARGETARCH/headless-shell/libEGL.so \
+    out/$VERSION/$TARGETARCH/headless-shell/libGLESv2.so \
+    out/$VERSION/$TARGETARCH/headless-shell/libvk_swiftshader.so \
+    out/$VERSION/$TARGETARCH/headless-shell/libvulkan.so.1 \
+    out/$VERSION/$TARGETARCH/headless-shell/vk_swiftshader_icd.json \
     /headless-shell/
 EXPOSE 9222
 ENV LANG en-US.UTF-8

--- a/README.md
+++ b/README.md
@@ -92,8 +92,18 @@ Chromium source tree, you can simply run [`build-docker.sh`](build-docker.sh):
 # build headless-shell
 $ ./build-headless-shell.sh /path/to/chromium/src 74.0.3717.1
 
+# build headless-shell for arm64
+$ ./build-headless-shell.sh -b /path/to/chromium/src -v 74.0.3717.1 -p arm64
+
 # build docker image (uses $PWD/out/headless-shell-$VER.tar.bz2)
 $ ./build-docker.sh 74.0.3717.1
+
+# build docker image for arm64
+$ ./build-docker.sh -v 74.0.3717.1 -p arm64
+
+# build multi-arch images using buildx (both ARM64 and AMD64 in one command)
+$ ./build-docker.sh -v 74.0.3717.1 -x
+
 ```
 
 [headless-shell]: https://github.com/chromedp/docker-headless-shell

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -10,25 +10,38 @@ fi
 TAGS=()
 UPDATE=0
 VERSION=
+ARCH=
+IMAGE_NAME="chromedp/headless-shell"
+USE_BUILDX=0
 
 OPTIND=1
-while getopts "t:uv:" opt; do
+while getopts "t:uv:p:i:x" opt; do
 case "$opt" in
   t) TAGS+=($OPTARG) ;;
   u) UPDATE=1 ;;
   v) VERSION=$OPTARG ;;
+  p) ARCH=$OPTARG ;;
+  i) IMAGE_NAME=$OPTARG ;;
+  x) USE_BUILDX=1 ;;
 esac
 done
 
 if [ -z "$VERSION" ]; then
   pushd $SRC/out &> /dev/null
-  VERSION=$(ls *.bz2|sort -r -V|head -1|sed -e 's/^headless-shell-//' -e 's/\.tar\.bz2$//')
+  VERSION=$(ls *.bz2|sort -r -V|head -1|sed -e 's/^headless-shell-//' -e 's/-.*\.tar\.bz2$//')
   popd &> /dev/null
+fi
+
+if [ -z "$ARCH" ]; then
+    ARCH="$(uname -m)"
+    if [ "$ARCH" = "x86_64" ]; then
+        ARCH="amd64"
+    fi
 fi
 
 set -e
 
-ARCHIVE=$SRC/out/headless-shell-$VERSION.tar.bz2
+ARCHIVE=$SRC/out/headless-shell-$VERSION-$ARCH.tar.bz2
 if [ ! -f $ARCHIVE ]; then
   echo "error: $ARCHIVE doesn't exist!"
   exit 1
@@ -43,16 +56,43 @@ if [ "$UPDATE" = "1" ]; then
   )
 fi
 
-PARAMS=(--tag chromedp/headless-shell:$VERSION)
+PARAMS=(--tag $IMAGE_NAME:$VERSION)
 for TAG in ${TAGS[@]}; do
-  PARAMS+=(--tag chromedp/headless-shell:$TAG)
+  PARAMS+=(--tag $IMAGE_NAME:$TAG)
 done
 
+if [[ $USE_BUILDX -eq 0 ]]; then
 (set -x;
-  rm -rf $SRC/out/$VERSION
-  mkdir -p  $SRC/out/$VERSION
-  tar -jxf $SRC/out/headless-shell-$VERSION.tar.bz2 -C $SRC/out/$VERSION/
-  docker build --build-arg VERSION=$VERSION ${PARAMS[@]} --quiet .
+  rm -rf $SRC/out/$VERSION/$ARCH
+  mkdir -p  $SRC/out/$VERSION/$ARCH
+  tar -jxf $SRC/out/headless-shell-$VERSION-$ARCH.tar.bz2 -C $SRC/out/$VERSION/$ARCH
+  docker build --build-arg VERSION=$VERSION --build-arg TARGETARCH=$ARCH ${PARAMS[@]} .
 )
+else
+(set -x;
+    rm -rf $SRC/out/$VERSION/amd64 $SRC/out/$VERSION/arm64
+    mkdir -p $SRC/out/$VERSION/amd64 $SRC/out/$VERSION/arm64
+    tar -jxf $SRC/out/headless-shell-$VERSION-amd64.tar.bz2 -C $SRC/out/$VERSION/amd64
+    tar -jxf $SRC/out/headless-shell-$VERSION-arm64.tar.bz2 -C $SRC/out/$VERSION/arm64
+
+    BUILDER_NAME="headless-shell-builder"
+    docker buildx inspect $BUILDER_NAME &> /dev/null || ret=$?
+
+    if [[ $ret -eq 1 ]]; then
+        echo "Creating builder instance..."
+        docker buildx create --name $BUILDER_NAME --driver=docker-container
+    else
+        echo "Builder instance '$BUILDER_NAME' already exists. Using existing builder..."
+   fi
+
+    echo "Running the build..."
+    docker buildx build --push --platform linux/arm64/v8,linux/amd64 --build-arg VERSION=$VERSION --tag "${IMAGE_NAME}:${VERSION}" --builder $BUILDER_NAME .
+
+    if [[ $ret -eq 1 ]]; then
+        echo "Stopping and removing the builder instance..."
+        docker buildx rm $BUILDER_NAME
+    fi
+)
+fi
 
 popd &> /dev/null


### PR DESCRIPTION
This change will enable the scripts and Dockerfile to build arm64 images, which should be useful for those who are using Apple silicon (M*) machines or Raspberry pi's. 

I have built arm64 images for headless-shell using these changes, and it works well in my M2 mac. 

In case someone wants to test it, I have pushed the images here: https://hub.docker.com/r/louiepascual/headless-shell/tags. The images there has both x86 and arm64 images.
