### PR TITLE
Pass entrypoint arguments to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,5 @@ exec /headless-shell/headless-shell \
   --use-gl=angle \
   --use-angle=swiftshader \
   --remote-debugging-address=0.0.0.0 \
-  --remote-debugging-port=9223
+  --remote-debugging-port=9223 \
+  $@ # Pass remaining arguments sent to the entrypoint


### PR DESCRIPTION
[A recent change](https://github.com/chromedp/docker-headless-shell/commit/7b48ea2cfdb0e0dcf9eafe1f9e48c094289409e4) to forward sockets introduced a new `run.sh` script to start headless-shell.

Previously, you could add arguments to the entrypoint when configuring the container in a Kubernetes manifest using the `args` field ([kube docs](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#define-a-command-and-arguments-when-you-create-a-pod)). With the new run.sh script, those arguments are not passed to the `/headless-shell/headless-shell` command like they were before.

This change simply adds a new opt to the end of the `run.sh` script to pass any additional arguments on `run.sh` to the `/headless-shell/headless-shell` command to allow the old behavior (passing arguments to the container's entrypoint) to continue working.