### PR TITLE
Dockerfile: Use --no-install-recommends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/debian:bookworm-slim
 ARG VERSION
 RUN \
     apt-get update -y \
-    && apt-get install -y libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1 socat \
+    && apt-get install --no-install-recommends -y libnspr4 libnss3 libexpat1 libfontconfig1 libuuid1 socat \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY \
     out/$VERSION/headless-shell/headless-shell \


### PR DESCRIPTION
This drops https://packages.debian.org/de/sid/krb5-locales which I believe is not needed.