### PR TITLE
Dockerfile: Use Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:bookworm-slim
+FROM docker.io/library/debian:trixie-slim
 ARG VERSION
 RUN \
     apt-get update -y \


### PR DESCRIPTION
https://www.debian.org/releases/trixie/

Allows for more recent packages than bookworm