### PR TITLE
Update platform from win64 to linux in version retrieval scripts

### DIFF
--- a/build-headless-shell.sh
+++ b/build-headless-shell.sh
@@ -40,7 +40,7 @@ fi
 
 # determine version
 if [ -z "$VERSION" ]; then
-  VERSION=$(verhist -platform win64 -channel $CHANNEL -latest)
+  VERSION=$(verhist -platform linux -channel $CHANNEL -latest)
 fi
 
 # determine out dir

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ echo "STARTING ($(date))"
 # determine versions
 declare -A VERSIONS
 for CHANNEL in ${CHANNELS[@]}; do
-  VERSIONS[$CHANNEL]=$(verhist -platform win64 -channel "$CHANNEL" -latest)
+  VERSIONS[$CHANNEL]=$(verhist -platform linux -channel "$CHANNEL" -latest)
 done
 
 # order channels low -> high

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -27,7 +27,7 @@ fi
 
 if [ ${#VERSIONS[@]} -eq 0 ]; then
   for CHANNEL in ${CHANNELS[@]}; do
-    VERSIONS+=($(verhist -platform win64 -channel "$CHANNEL" -latest))
+    VERSIONS+=($(verhist -platform linux -channel "$CHANNEL" -latest))
   done
 fi
 


### PR DESCRIPTION
Since these scripts build Docker images for platform linux, they should fetch Chrome versions for Linux, not Windows. Latest versions can differ between platforms (e.g., stable is currently 144.0.7559.97 for win64 vs 144.0.7559.96 for linux).

[Stable Channel Update for Desktop](https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_20.html)

Also verhist results show the same:
```sh
❯ go run github.com/chromedp/verhist/cmd/verhist@master -platform linux -channel stable -latest
144.0.7559.96

❯ go run github.com/chromedp/verhist/cmd/verhist@master -platform win64 -channel stable -latest
144.0.7559.97
```