### PR TITLE
Include headless_*.pak resource files in build and Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY \
     out/$VERSION/headless-shell/libvk_swiftshader.so \
     out/$VERSION/headless-shell/libvulkan.so.1 \
     out/$VERSION/headless-shell/vk_swiftshader_icd.json \
+    out/$VERSION/headless-shell/headless_*.pak \
     /headless-shell/
 COPY run.sh /headless-shell/
 EXPOSE 9222

--- a/build-headless-shell.sh
+++ b/build-headless-shell.sh
@@ -243,6 +243,10 @@ for TARGET in ${TARGETS[@]}; do
   (set -x;
     cp -a $PROJECT/headless_shell $WORKDIR/headless-shell
     cp -a $PROJECT/{.stamp,libEGL.so,libGLESv2.so,libvk_swiftshader.so,libvulkan.so.1,vk_swiftshader_icd.json} $WORKDIR
+    # Copy .pak resource files (UA stylesheet, etc.) — required since Chromium 146
+    for f in $PROJECT/headless_*.pak; do
+      [ -f "$f" ] && cp -a "$f" $WORKDIR
+    done
     $STRIP $WORKDIR/headless-shell $WORKDIR/*.so{,.1}
     chmod -x $WORKDIR/*.so{,.1}
     du -s $WORKDIR/*


### PR DESCRIPTION
Howdy! I believe this build change fixes the issues reported where the root stylesheet isn't found. A coding agent was involved here, but I observed it build the Docker thing, and put the files in place, and, separately observed that those files being put in place fixed my underlying issues. Totally understand if you'd prefer another approach!

Starting with Chromium 146, the headless_shell build produces .pak resource files (headless_command_resources.pak, headless_lib_data.pak, headless_lib_strings.pak) that contain the user-agent stylesheet and other critical rendering resources. Without these files, headless-shell renders all HTML elements as inline (no block-level layout), <style> and <script> tags are visible as text, and display:none from stylesheets has no effect.

Previously these resources were compiled into the headless_shell binary, but Chromium 146 moved them into external .pak files. The build script and Dockerfile were not updated to include them.

Fixes chromedp/chromedp#1619
Fixes chromedp/chromedp#1621